### PR TITLE
Support Google OCR JSON files

### DIFF
--- a/blueprint/py/bp/build_document.py
+++ b/blueprint/py/bp/build_document.py
@@ -56,6 +56,7 @@ def build_document(
   Args:
     input_pages: The pages of the document and the words on those pages.
       The pages should be given in order.
+    name: The name of the document.
   """
 
   sorted_page_numbers = tuple(

--- a/blueprint/py/bp/cli/run_model.py
+++ b/blueprint/py/bp/cli/run_model.py
@@ -84,23 +84,24 @@ def main_run_model(args: Namespace) -> None:
         return path.parent / file_path
     return list(map(compute_path, file_paths))
 
+  docs: Tuple[Document, ...] = tuple()
   if args.bundle:
     doc_path = Path(args.bundle) / Path('selectedDoc.json')
     if not doc_path.is_file():
       raise RuntimeError('invalid bundle; missing selectedDoc.json')
-    docs: Tuple[Document, ...] = (load_doc(doc_path),)
+    docs += (load_doc(doc_path),)
   if args.doc_jsons:
     doc_paths = [Path(p) for p in args.doc_jsons]
-    docs = tuple(load_doc(path) for path in doc_paths)
+    docs += tuple(load_doc(path) for path in doc_paths)
   if args.doc_jsons_list:
     doc_paths = read_paths_from_file(Path(args.doc_jsons_list))
-    docs = tuple(load_doc(path) for path in doc_paths)
+    docs += tuple(load_doc(path) for path in doc_paths)
 
   if args.google_ocr_jsons:
-    docs = tuple(load_doc_from_google_ocr(Path(path))
+    docs += tuple(load_doc_from_google_ocr(Path(path))
       for path in args.google_ocr_jsons)
   if args.ibocr_jsons:
-    docs = tuple(load_doc_from_ibocr(Path(path))
+    docs += tuple(load_doc_from_ibocr(Path(path))
       for path in args.ibocr_jsons)
 
   # Set up the output directory

--- a/blueprint/py/bp/cli/run_model.py
+++ b/blueprint/py/bp/cli/run_model.py
@@ -16,6 +16,8 @@ from ..config import Config, load_config
 from ..document import Document, load_doc
 from ..extraction import Extraction, load_extraction
 from ..functional import all_equal, nonempty, uniq
+from ..google_ocr_file import load_doc_from_google_ocr
+from ..ibocr_file import load_doc_from_ibocr
 from ..model import load_model, save_model
 from ..results import save_results
 from ..run import run_model
@@ -82,19 +84,24 @@ def main_run_model(args: Namespace) -> None:
         return path.parent / file_path
     return list(map(compute_path, file_paths))
 
-  doc_paths: List[Path] = []
-
   if args.bundle:
     doc_path = Path(args.bundle) / Path('selectedDoc.json')
     if not doc_path.is_file():
       raise RuntimeError('invalid bundle; missing selectedDoc.json')
-    doc_paths += [doc_path]
+    docs: Tuple[Document, ...] = (load_doc(doc_path),)
   if args.doc_jsons:
-    doc_paths += [Path(p) for p in args.doc_jsons]
+    doc_paths = [Path(p) for p in args.doc_jsons]
+    docs = tuple(load_doc(path) for path in doc_paths)
   if args.doc_jsons_list:
-    doc_paths += read_paths_from_file(Path(args.doc_jsons_list))
+    doc_paths = read_paths_from_file(Path(args.doc_jsons_list))
+    docs = tuple(load_doc(path) for path in doc_paths)
 
-  docs = tuple(load_doc(path) for path in doc_paths)
+  if args.google_ocr_jsons:
+    docs = tuple(load_doc_from_google_ocr(Path(path))
+      for path in args.google_ocr_jsons)
+  if args.ibocr_jsons:
+    docs = tuple(load_doc_from_ibocr(Path(path))
+      for path in args.ibocr_jsons)
 
   # Set up the output directory
   # ===========================
@@ -148,6 +155,13 @@ def init_run_model(subparsers: _SubParsersAction) -> None:
     'paths may be absolute, '
     'or relative to the directory containing this file',
     type=str, metavar='LIST_FILE')
+  parser.add_argument('-g', '--google-ocr-jsons',
+    help='Google OCR JSON files for input documents',
+    type=str, metavar='FILE', nargs='*', default=list())
+  parser.add_argument('-i', '--ibocr-jsons',
+    help='IBOCR JSON files for input documents',
+    type=str, metavar='FILE', nargs='*', default=list())
+
   parser.add_argument('-o', '--output-dir',
     help='Output directory',
     type=str)

--- a/blueprint/py/bp/google_ocr_file.py
+++ b/blueprint/py/bp/google_ocr_file.py
@@ -1,0 +1,64 @@
+"""Generate BP docs from Google Cloud Vision OCR files."""
+
+import json
+import logging
+
+from itertools import chain
+from pathlib import Path
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple
+
+from .build_document import InputPage, InputWord, build_document
+from .document import Document
+from .entity import Page
+from .geometry import BBox, Interval
+
+
+def _bbox(vertices: List[Dict]) -> BBox:
+  if len(vertices) != 4:
+    raise ValueError(f'invalid vertices {vertices}, must be length 4')
+  x0: float = vertices[0]['x']
+  x1: float = vertices[1]['x']
+  y0: float = vertices[0]['y']
+  y1: float = vertices[2]['y']
+  return BBox(Interval.spanning([x0, x1]),
+              Interval.spanning([y0, y1]))
+
+
+def _get_input_word_from_google_word(word: Dict) -> InputWord:
+  bbox = _bbox(word['boundingBox']['vertices'])
+  text = ''.join(symbol['text'] for symbol in word['symbols'])
+  return InputWord(bbox, text)
+
+
+def _get_words_from_page(page: Dict) -> Tuple[InputWord, ...]:
+  def get_words_from_paragraph(paragraph: Dict) -> Tuple[InputWord, ...]:
+    return tuple(_get_input_word_from_google_word(word)
+      for word in paragraph['words'])
+  def get_words_from_block(block: Dict) -> Tuple[InputWord, ...]:
+    return tuple(chain.from_iterable(get_words_from_paragraph(paragraph)
+      for paragraph in block['paragraphs']))
+  return tuple(chain.from_iterable(get_words_from_block(block)
+    for block in page['blocks']))
+
+
+def generate_doc_from_google_ocr_json(raw_json: Dict, name: str) -> Document:
+  document_pages = raw_json['fullTextAnnotation']['pages']
+
+  def prepare_input_page(page_number: int, page: Dict) -> InputPage:
+    input_words = _get_words_from_page(page)
+    y_offset = sum(document_pages[i]['height'] for i in range(page_number))
+    bp_page = Page(
+      BBox(
+        Interval(0, page['width']),
+        Interval(y_offset, page['height'] + y_offset)),
+      page_number + 1)
+    return InputPage(bp_page, input_words)
+
+  input_pages = tuple(prepare_input_page(page_number, page)
+    for page_number, page in enumerate(document_pages))
+  return build_document(input_pages, name)
+
+
+def load_doc_from_google_ocr(path: Path) -> Document:
+  with path.open() as f:
+    return generate_doc_from_google_ocr_json(json.load(f), path.stem)

--- a/blueprint/py/bp/ibocr_file.py
+++ b/blueprint/py/bp/ibocr_file.py
@@ -55,3 +55,7 @@ def generate_doc_from_ibocr(raw_json: Any, name: str) -> Document:
   input_pages = tuple(prepare_input_page(page_number)
     for page_number in range(len(layouts)))
   return build_document(input_pages, name)
+
+def load_doc_from_ibocr(path: Path) -> Document:
+  with path.open() as f:
+    return generate_doc_from_ibocr(json.load(f), path.stem)

--- a/blueprint/py/bp/instantiate.py
+++ b/blueprint/py/bp/instantiate.py
@@ -74,7 +74,7 @@ def instantiate(t: typing.Type[T], v: typing.Any,
   # These may not be part of the official API...
   KT = typing.KT # type: ignore
   VT = typing.VT # type: ignore
-  def get_forward_arg(t: typing.ForwardRef) -> str:
+  def get_forward_arg(t: typing.ForwardRef) -> str: # type: ignore
     return t.__forward_arg__
 
   def is_optional(t: typing.Type[T]) -> bool:
@@ -141,7 +141,7 @@ def instantiate(t: typing.Type[T], v: typing.Any,
     else:
       return v # type: ignore
 
-  elif isinstance(t, typing.ForwardRef):
+  elif isinstance(t, typing.ForwardRef): # type: ignore
     t_name = get_forward_arg(t)
     if FRR and t_name in FRR:
       return instantiate(


### PR DESCRIPTION
Can now run on the output of Google Cloud Vision OCR engine.

To try:
- Upload image here: https://cloud.google.com/vision/docs/drag-and-drop
- Navigate to the `Text` tab and click "Show JSON"
- Save a JSON file with the entire Response
- Example usage: `python3 paystubs.py run_model -v -g <path-to-json-file>`